### PR TITLE
nested-mess | Enhance report UI with dual buffer system and span filtering

### DIFF
--- a/lua/observe/_types.lua
+++ b/lua/observe/_types.lua
@@ -1,3 +1,8 @@
+---@class ObserveConfig
+---@field adapters table<HandlerType, boolean>?
+---@field max_spans integer?
+---@field max_timeline_spans integer?
+
 ---@class ObserveState
 ---@field enabled boolean
 ---@field config ObserveConfig
@@ -63,7 +68,6 @@
 ---@field span_id integer
 
 ---@class ReportUIState: TimelineViewState
----@field show_timeline boolean
 ---@field info_extmarks table<integer, ExtInfo>
 ---@field timeline_extmarks table<integer, ExtInfo>
 

--- a/lua/observe/_types.lua
+++ b/lua/observe/_types.lua
@@ -64,7 +64,8 @@
 
 ---@class ReportUIState: TimelineViewState
 ---@field show_timeline boolean
----@field extmarks table<integer, ExtInfo>
+---@field info_extmarks table<integer, ExtInfo>
+---@field timeline_extmarks table<integer, ExtInfo>
 
 ---@class RenderLineMeta
 ---@field span_id integer?

--- a/lua/observe/adapters/autocmd.lua
+++ b/lua/observe/adapters/autocmd.lua
@@ -37,7 +37,7 @@ local function callback_label(cb)
 		return { label = "cmd" }
 	end
 
-	return { label = "unknown" }
+	return { label = "?" }
 end
 
 ---Observe the callback time

--- a/lua/observe/adapters/cmd.lua
+++ b/lua/observe/adapters/cmd.lua
@@ -36,7 +36,7 @@ local function wrap_callback(cb, kind, ...)
 		meta.cmd = kind
 	end
 
-	store.begin_span(("Cmd: %s"):format(meta.cmd), meta, parent_id)
+	store.begin_span(("Cmd: %s (%s)"):format(meta.cmd, meta.source), meta, parent_id)
 
 	local results = { pcall(cb, ...) }
 
@@ -49,24 +49,31 @@ local function wrap_callback(cb, kind, ...)
 	return unpack(results)
 end
 
-local function wrap_async_callback(cb, kind)
-	local info = path_utils.determine_source()
-	local parent_id = store.get_parent_id()
-
-	return function(...)
-		if not info then
-			cb(...)
-			return
-		end
-
-		local source = "async_cmd"
-		if info.truncated_source and info.current_line then
-			source = path_utils.get_formatted_line(info.truncated_source, info.current_line)
-		end
-
-		local full_source
+---Get truncated and full source of the executed cmd
+---@param info DebugInfo|nil
+---@return string|nil
+---@return string|nil
+local function get_source_data(info)
+	local source, full_source
+	if info and info.truncated_source and info.current_line then
+		source = path_utils.get_formatted_line(info.truncated_source, info.current_line)
 		if info.full_source and info.current_line then
 			full_source = path_utils.get_formatted_line(info.full_source, info.current_line)
+		end
+	end
+	return source, full_source
+end
+
+local function wrap_async_callback(cb, kind)
+	local parent_id = store.get_parent_id()
+	local info = path_utils.determine_source()
+
+	return function(...)
+		local source, full_source
+
+		source, full_source = get_source_data(info)
+		if not source then
+			source = "?"
 		end
 
 		local meta = {
@@ -76,7 +83,7 @@ local function wrap_async_callback(cb, kind)
 			full_source = full_source,
 		}
 
-		store.begin_span(("Async: %s"):format(kind), meta, parent_id)
+		store.begin_span(("Async: %s (%s)"):format(kind, source), meta, parent_id)
 		local results = { pcall(cb, ...) }
 		store.finish_span()
 

--- a/lua/observe/config.lua
+++ b/lua/observe/config.lua
@@ -2,11 +2,6 @@ local constants = require("observe.constants")
 
 local M = {}
 
----@class ObserveConfig
----@field adapters table<HandlerType, boolean>?
----@field max_spans integer?
----@field max_timeline_spans integer?
-
 ---@type ObserveConfig
 M.defaults = {
 	adapters = {},

--- a/lua/observe/core/store.lua
+++ b/lua/observe/core/store.lua
@@ -90,6 +90,12 @@ function M.finish_span()
 	local h = table.remove(state.active_spans) ---@type StartObserveSpan
 	local end_ns = clock.now_ns()
 
+	-- Filter spans less than 1ms
+	local ns = end_ns - h.start_ns
+	if ns < 1e6 then
+		return
+	end
+
 	---@type ObserveSpan
 	local span = vim.tbl_deep_extend(
 		"force",

--- a/lua/observe/init.lua
+++ b/lua/observe/init.lua
@@ -59,8 +59,17 @@ function M.report()
 		return
 	end
 
-	vim.notify("Generating report...", vim.log.levels.INFO, { title = constants.PLUGIN_NAME })
 	local spans = store.get_spans()
+	if #spans <= 0 then
+		vim.notify(
+			"There is no recorded data. Please trace first using ObserveStart!",
+			vim.log.levels.INFO,
+			{ title = constants.PLUGIN_NAME }
+		)
+		return
+	end
+
+	vim.notify("Generating report...", vim.log.levels.INFO, { title = constants.PLUGIN_NAME })
 	local info_lines, timeline_lines = view.render(spans)
 	report.open_report(info_lines, timeline_lines)
 end

--- a/lua/observe/init.lua
+++ b/lua/observe/init.lua
@@ -47,6 +47,7 @@ function M.stop()
 	state.enabled = false
 	adapters.disable()
 	store.disable()
+	M.report()
 
 	vim.notify("Tracing stopped!", vim.log.levels.INFO, { title = constants.PLUGIN_NAME })
 end
@@ -60,8 +61,8 @@ function M.report()
 
 	vim.notify("Generating report...", vim.log.levels.INFO, { title = constants.PLUGIN_NAME })
 	local spans = store.get_spans()
-	local lines = view.render(spans)
-	report.open_report(lines)
+	local info_lines, timeline_lines = view.render(spans)
+	report.open_report(info_lines, timeline_lines)
 end
 
 ---Check if tracing is currently active

--- a/lua/observe/ui/report.lua
+++ b/lua/observe/ui/report.lua
@@ -243,9 +243,11 @@ function M.open_report(info_lines, timeline_lines)
 	info_buf = ensure_info_buf(true)
 	if info_buf then
 		vim.cmd("botright 15split")
+		win_util.clean_window()
 		vim.api.nvim_win_set_buf(0, info_buf)
 		if timeline_buf then
 			vim.cmd("botright 40vsplit")
+			win_util.clean_window()
 			vim.api.nvim_win_set_buf(0, timeline_buf)
 		end
 	end

--- a/lua/observe/ui/report.lua
+++ b/lua/observe/ui/report.lua
@@ -1,16 +1,22 @@
+-- TODO: NEED TO MAKE DESIGN DECISION OF CURRENTLY IMPLEMENTED BUFFER SYSTEM
+-- MAYBE JUST LIKE OUR RIGHT SIDE OUTLINE view
+-- ADD ICONS, COMMENT HIGHLIGHT OUT THE PATH, SET A WIDTH FOR THE BUFFER
+
 local store = require("observe.core.store")
 local view = require("observe.ui.view")
 local path_utils = require("observe.utils.path")
 local extmarks = require("observe.utils.extmarks")
 
-local REPORT_NAME = "observe://report"
+local REPORT_INFO = "observe://report-info"
+local REPORT_TIMELINE = "observe://report-timeline"
 local REPORT_FILETYPE = "observe-report"
 local ns_marks = vim.api.nvim_create_namespace(REPORT_FILETYPE)
 local ns_hl = vim.api.nvim_create_namespace(REPORT_FILETYPE .. "-hl")
 
 local M = {}
 
-local report_buf ---@type integer?
+local report_info_buf ---@type integer?
+local report_timeline_buf ---@type integer?
 
 ---Set highlights
 local function ensure_highlights()
@@ -18,6 +24,7 @@ local function ensure_highlights()
 	vim.api.nvim_set_hl(0, "ObserveTitle", { bold = true })
 end
 
+--TODO: Gotta fix it up for two windows
 ---Apply highlights to buffer
 local function apply_highlights(buf, lines)
 	vim.api.nvim_buf_clear_namespace(buf, ns_hl, 0, -1)
@@ -43,23 +50,37 @@ local function apply_highlights(buf, lines)
 	end
 end
 
----Open a new buffer if there isn't already a valid one,
----set keymap 'q' to close and 't' to toggle timeline, and return the buffer
+---Create and return buffer
+---@param name string
 ---@return integer
-local function ensure_buf()
-	if report_buf and vim.api.nvim_buf_is_valid(report_buf) then
-		return report_buf
-	end
-
+local function ensure_buf(name)
 	local buf = vim.api.nvim_create_buf(false, true)
-	report_buf = buf
-	vim.api.nvim_buf_set_name(buf, REPORT_NAME)
+	vim.api.nvim_buf_set_name(buf, name)
 	vim.bo[buf].buftype = "nofile"
 	vim.bo[buf].bufhidden = "hide"
 	vim.bo[buf].swapfile = false
 	vim.bo[buf].modifiable = false
 	vim.bo[buf].filetype = REPORT_FILETYPE
+	return buf
+end
 
+---Open a new timeline buffer if there isn't already a valid one,
+---set keymap 'q' to close, 'h' to hide, 'i' to toggle info, and return the buffer
+---@param force boolean
+---@return integer|nil
+local function ensure_timeline_buf(force)
+	if report_timeline_buf and vim.api.nvim_buf_is_valid(report_timeline_buf) then
+		return report_timeline_buf
+	end
+
+	if not force then
+		return nil
+	end
+
+	local buf = ensure_buf(REPORT_TIMELINE)
+	report_timeline_buf = buf
+
+	--TODO: need to close both windows and extract function and make it reusable
 	vim.keymap.set("n", "q", function()
 		local wins = vim.api.nvim_list_wins()
 		if #wins > 1 then
@@ -75,14 +96,16 @@ local function ensure_buf()
 		pcall(vim.api.nvim_buf_delete, cur_buf, { force = true })
 	end, { buffer = buf, nowait = true, silent = true })
 
-	vim.keymap.set("n", "t", function()
-		M.toggle_timeline()
-	end, { buffer = buf, desc = "Toggle timeline in report" })
+	-- TODO: Toggle info (DO WE ACTUALLY NEED TO DO IT THO?)
+	-- vim.keymap.set("n", "i", function()
+	-- 	M.toggle_timeline()
+	-- end, { buffer = buf, desc = "Toggle timeline in report" })
 
+	--TODO: need to extract function and make it reusable
 	vim.keymap.set("n", "<CR>", function()
 		local row = vim.api.nvim_win_get_cursor(0)[1] - 1
 
-		local marks = vim.api.nvim_buf_get_extmarks(report_buf, ns_marks, { row, 0 }, { row, -1 }, {})
+		local marks = vim.api.nvim_buf_get_extmarks(report_timeline_buf, ns_marks, { row, 0 }, { row, -1 }, {})
 		if #marks == 0 then
 			return
 		end
@@ -92,13 +115,13 @@ local function ensure_buf()
 			return
 		end
 
-		path_utils.open_location_enter(report_buf, info.source)
+		path_utils.open_location_enter(report_timeline_buf, info.source)
 	end, { buffer = buf, desc = "Open source file" })
 
 	vim.keymap.set("n", "e", function()
 		local row = vim.api.nvim_win_get_cursor(0)[1] - 1
 
-		local marks = vim.api.nvim_buf_get_extmarks(report_buf, ns_marks, { row, 0 }, { row, -1 }, {})
+		local marks = vim.api.nvim_buf_get_extmarks(report_timeline_buf, ns_marks, { row, 0 }, { row, -1 }, {})
 		if #marks == 0 then
 			return
 		end
@@ -127,6 +150,63 @@ local function ensure_buf()
 	return buf
 end
 
+---Open a new info buffer if there isn't already a valid one,
+---set keymap 'q' to close, 'h' to hide, 't' to toggle timeline, and return the buffer
+---@param force boolean
+---@return integer|nil
+local function ensure_info_buf(force)
+	if report_info_buf and vim.api.nvim_buf_is_valid(report_info_buf) then
+		return report_info_buf
+	end
+
+	if not force then
+		return nil
+	end
+
+	local buf = ensure_buf(REPORT_INFO)
+	report_info_buf = buf
+
+	--TODO: need to close both report split, also need to extract function and make it reusable
+	vim.keymap.set("n", "q", function()
+		local wins = vim.api.nvim_list_wins()
+		if #wins > 1 then
+			-- if there are more than 1 window, close the current window
+			pcall(vim.api.nvim_win_close, 0, false)
+			return
+		end
+
+		-- if there is only 1 window,
+		-- create a new buffer inside the window and close the current report buffer
+		local cur_buf = vim.api.nvim_get_current_buf()
+		vim.cmd("enew")
+		pcall(vim.api.nvim_buf_delete, cur_buf, { force = true })
+	end, { buffer = buf, nowait = true, silent = true })
+
+	-- TODO: Toggle timeline (DO WE ACTUALLY NEED TO DO IT THO?)
+	-- vim.keymap.set("n", "t", function()
+	-- 	M.toggle_timeline()
+	-- end, { buffer = buf, desc = "Toggle timeline in report" })
+
+	--TODO: need to extract function and make it reusable
+	vim.keymap.set("n", "<CR>", function()
+		local row = vim.api.nvim_win_get_cursor(0)[1] - 1
+
+		local marks = vim.api.nvim_buf_get_extmarks(report_info_buf, ns_marks, { row, 0 }, { row, -1 }, {})
+		if #marks == 0 then
+			return
+		end
+
+		local info = extmarks.get_extmark_data(marks)
+		if not info or not info.source then
+			return
+		end
+
+		path_utils.open_location_enter(report_info_buf, info.source)
+	end, { buffer = buf, desc = "Open source file" })
+
+	return buf
+end
+
 ---@param buf integer
 ---@param lines string[]
 local function set_lines(buf, lines)
@@ -136,20 +216,24 @@ local function set_lines(buf, lines)
 
 	vim.api.nvim_buf_clear_namespace(buf, ns_marks, 0, -1)
 
-	local marks = view.get_extmarks()
-	if marks then
-		for i = 1, #lines do
-			local info = marks[i]
-			if info then
-				local ext = vim.api.nvim_buf_set_extmark(buf, ns_marks, i - 1, 0, {})
-				local src
-				if info.source and info.source ~= "" then
-					src = info.source
-				end
+	local marks
+	if buf == report_info_buf then
+		marks = view.get_info_extmarks()
+	elseif buf == report_timeline_buf then
+		marks = view.get_timeline_extmarks()
+	end
 
-				local data = { source = src, span_id = info.span_id }
-				store.set_mark(ext, data)
+	for i = 1, #lines do
+		local info = marks[i]
+		if info then
+			local ext = vim.api.nvim_buf_set_extmark(buf, ns_marks, i - 1, 0, {})
+			local src
+			if info.source and info.source ~= "" then
+				src = info.source
 			end
+
+			local data = { source = src, span_id = info.span_id }
+			store.set_mark(ext, data)
 		end
 	end
 
@@ -157,12 +241,18 @@ local function set_lines(buf, lines)
 end
 
 ---Return window that contains the buffer
----@param buf integer
+---@param info_buf integer?
+---@param timeline_buf integer?
 ---@return integer|nil
-local function find_window_showing_buf(buf)
+local function find_window_showing_buf(info_buf, timeline_buf)
+	if not info_buf and not timeline_buf then
+		return nil
+	end
+
 	local wins = vim.api.nvim_list_wins()
 	for _, win in pairs(wins) do
-		if vim.api.nvim_win_get_buf(win) == buf then
+		local curr_win = vim.api.nvim_win_get_buf(win)
+		if curr_win == info_buf or curr_win == timeline_buf then
 			return win
 		end
 	end
@@ -170,72 +260,98 @@ local function find_window_showing_buf(buf)
 	return nil
 end
 
+---Set lines of info and timeline buffer
+---@param info_lines string[]
+---@param timeline_lines string[]
+local function set_buf_lines(info_lines, timeline_lines)
+	local info_buf = ensure_info_buf(false)
+	local timeline_buf = ensure_timeline_buf(info_buf and false or true)
+
+	if timeline_buf then
+		set_lines(timeline_buf, timeline_lines)
+	end
+
+	if info_buf then
+		set_lines(info_buf, info_lines)
+	end
+
+	vim.cmd("normal! gg")
+end
+
 ---Open report in buffer
----@param lines string[]
-function M.open_report(lines)
-	local buf = ensure_buf()
+---@param info_lines string[]
+---@param timeline_lines string[]
+function M.open_report(info_lines, timeline_lines)
+	local timeline_buf = ensure_timeline_buf(false)
+	local info_buf = ensure_info_buf(false)
 	ensure_highlights()
 
 	local cur_buf = vim.api.nvim_get_current_buf()
 
 	-- Refresh only if user is already in report buffer
-	if cur_buf == buf then
-		set_lines(buf, lines)
-		vim.cmd("normal! gg")
+	if cur_buf == timeline_buf or cur_buf == info_buf then
+		set_buf_lines(info_lines, timeline_lines)
 		return
 	end
 
-	local existing_win = find_window_showing_buf(buf)
+	local existing_win = find_window_showing_buf(timeline_buf, info_buf)
 	if existing_win then
 		vim.api.nvim_set_current_win(existing_win)
-		set_lines(buf, lines)
-		vim.cmd("normal! gg")
+		set_buf_lines(info_lines, timeline_lines)
 		return
 	end
 
-	vim.cmd("botright split")
-	vim.api.nvim_win_set_buf(0, buf)
-	set_lines(buf, lines)
-	vim.cmd("normal! gg")
-end
-
----Toggle to view/hide timeline spans
-function M.toggle_timeline()
-	local buf = ensure_buf()
-	local cur_buf = vim.api.nvim_get_current_buf()
-
-	if cur_buf ~= buf then
-		return
+	timeline_buf = ensure_timeline_buf(true)
+	info_buf = ensure_info_buf(true)
+	if info_buf then
+		vim.cmd("botright split")
+		vim.api.nvim_win_set_buf(0, info_buf)
+		if timeline_buf then
+			vim.cmd("botright vsplit")
+			vim.api.nvim_win_set_buf(0, timeline_buf)
+		end
 	end
 
-	local saved_view = vim.fn.winsaveview()
-
-	view.toggle_timeline_view()
-
-	local spans = store.get_spans()
-	local lines = view.render(spans)
-	set_lines(buf, lines)
-
-	local height = vim.api.nvim_win_get_height(0)
-	local max_topline = math.max(1, #lines - height + 1)
-	saved_view.topline = math.min(saved_view.topline, max_topline)
-
-	vim.fn.winrestview(saved_view)
+	set_buf_lines(info_lines, timeline_lines)
 end
+
+-- ---Toggle to view/hide timeline spans
+-- function M.toggle_timeline()
+-- 	local buf = ensure_info_buf()
+-- 	local cur_buf = vim.api.nvim_get_current_buf()
+--
+-- 	if cur_buf ~= buf then
+-- 		return
+-- 	end
+--
+-- 	local saved_view = vim.fn.winsaveview()
+--
+-- 	view.toggle_timeline_view()
+--
+-- 	local spans = store.get_spans()
+-- 	local lines = view.render(spans)
+-- 	set_lines(buf, lines)
+--
+-- 	local height = vim.api.nvim_win_get_height(0)
+-- 	local max_topline = math.max(1, #lines - height + 1)
+-- 	saved_view.topline = math.min(saved_view.topline, max_topline)
+--
+-- 	vim.fn.winrestview(saved_view)
+-- end
 
 ---Toggle span in timeline and render its child
 ---@param span_id integer
 function M.toggle_span_and_render(span_id)
-	local buf = ensure_buf()
+	local buf = ensure_timeline_buf(false)
 	local cur_buf = vim.api.nvim_get_current_buf()
 
-	if cur_buf ~= buf then
+	if not buf or cur_buf ~= buf then
 		return
 	end
 
 	local saved_view = vim.fn.winsaveview()
 	local spans = store.toggle_span_view(span_id)
-	local lines = view.render(spans)
+	local _, lines = view.render(spans)
 	set_lines(buf, lines)
 	vim.fn.winrestview(saved_view)
 end

--- a/lua/observe/ui/report.lua
+++ b/lua/observe/ui/report.lua
@@ -4,8 +4,7 @@
 
 local store = require("observe.core.store")
 local view = require("observe.ui.view")
-local path_utils = require("observe.utils.path")
-local extmarks = require("observe.utils.extmarks")
+local win_util = require("observe.utils.win")
 
 local REPORT_INFO = "observe://report-info"
 local REPORT_TIMELINE = "observe://report-timeline"
@@ -24,7 +23,6 @@ local function ensure_highlights()
 	vim.api.nvim_set_hl(0, "ObserveTitle", { bold = true })
 end
 
---TODO: Gotta fix it up for two windows
 ---Apply highlights to buffer
 local function apply_highlights(buf, lines)
 	vim.api.nvim_buf_clear_namespace(buf, ns_hl, 0, -1)
@@ -80,42 +78,12 @@ local function ensure_timeline_buf(force)
 	local buf = ensure_buf(REPORT_TIMELINE)
 	report_timeline_buf = buf
 
-	--TODO: need to close both windows and extract function and make it reusable
 	vim.keymap.set("n", "q", function()
-		local wins = vim.api.nvim_list_wins()
-		if #wins > 1 then
-			-- if there are more than 1 window, close the current window
-			pcall(vim.api.nvim_win_close, 0, false)
-			return
-		end
-
-		-- if there is only 1 window,
-		-- create a new buffer inside the window and close the current report buffer
-		local cur_buf = vim.api.nvim_get_current_buf()
-		vim.cmd("enew")
-		pcall(vim.api.nvim_buf_delete, cur_buf, { force = true })
+		win_util.close_window()
 	end, { buffer = buf, nowait = true, silent = true })
 
-	-- TODO: Toggle info (DO WE ACTUALLY NEED TO DO IT THO?)
-	-- vim.keymap.set("n", "i", function()
-	-- 	M.toggle_timeline()
-	-- end, { buffer = buf, desc = "Toggle timeline in report" })
-
-	--TODO: need to extract function and make it reusable
 	vim.keymap.set("n", "<CR>", function()
-		local row = vim.api.nvim_win_get_cursor(0)[1] - 1
-
-		local marks = vim.api.nvim_buf_get_extmarks(report_timeline_buf, ns_marks, { row, 0 }, { row, -1 }, {})
-		if #marks == 0 then
-			return
-		end
-
-		local info = extmarks.get_extmark_data(marks)
-		if not info or not info.source then
-			return
-		end
-
-		path_utils.open_location_enter(report_timeline_buf, info.source)
+		win_util.open_file(report_timeline_buf, ns_marks)
 	end, { buffer = buf, desc = "Open source file" })
 
 	vim.keymap.set("n", "e", function()
@@ -166,42 +134,12 @@ local function ensure_info_buf(force)
 	local buf = ensure_buf(REPORT_INFO)
 	report_info_buf = buf
 
-	--TODO: need to close both report split, also need to extract function and make it reusable
 	vim.keymap.set("n", "q", function()
-		local wins = vim.api.nvim_list_wins()
-		if #wins > 1 then
-			-- if there are more than 1 window, close the current window
-			pcall(vim.api.nvim_win_close, 0, false)
-			return
-		end
-
-		-- if there is only 1 window,
-		-- create a new buffer inside the window and close the current report buffer
-		local cur_buf = vim.api.nvim_get_current_buf()
-		vim.cmd("enew")
-		pcall(vim.api.nvim_buf_delete, cur_buf, { force = true })
+		win_util.close_window()
 	end, { buffer = buf, nowait = true, silent = true })
 
-	-- TODO: Toggle timeline (DO WE ACTUALLY NEED TO DO IT THO?)
-	-- vim.keymap.set("n", "t", function()
-	-- 	M.toggle_timeline()
-	-- end, { buffer = buf, desc = "Toggle timeline in report" })
-
-	--TODO: need to extract function and make it reusable
 	vim.keymap.set("n", "<CR>", function()
-		local row = vim.api.nvim_win_get_cursor(0)[1] - 1
-
-		local marks = vim.api.nvim_buf_get_extmarks(report_info_buf, ns_marks, { row, 0 }, { row, -1 }, {})
-		if #marks == 0 then
-			return
-		end
-
-		local info = extmarks.get_extmark_data(marks)
-		if not info or not info.source then
-			return
-		end
-
-		path_utils.open_location_enter(report_info_buf, info.source)
+		win_util.open_file(report_info_buf, ns_marks)
 	end, { buffer = buf, desc = "Open source file" })
 
 	return buf
@@ -304,40 +242,16 @@ function M.open_report(info_lines, timeline_lines)
 	timeline_buf = ensure_timeline_buf(true)
 	info_buf = ensure_info_buf(true)
 	if info_buf then
-		vim.cmd("botright split")
+		vim.cmd("botright 15split")
 		vim.api.nvim_win_set_buf(0, info_buf)
 		if timeline_buf then
-			vim.cmd("botright vsplit")
+			vim.cmd("botright 40vsplit")
 			vim.api.nvim_win_set_buf(0, timeline_buf)
 		end
 	end
 
 	set_buf_lines(info_lines, timeline_lines)
 end
-
--- ---Toggle to view/hide timeline spans
--- function M.toggle_timeline()
--- 	local buf = ensure_info_buf()
--- 	local cur_buf = vim.api.nvim_get_current_buf()
---
--- 	if cur_buf ~= buf then
--- 		return
--- 	end
---
--- 	local saved_view = vim.fn.winsaveview()
---
--- 	view.toggle_timeline_view()
---
--- 	local spans = store.get_spans()
--- 	local lines = view.render(spans)
--- 	set_lines(buf, lines)
---
--- 	local height = vim.api.nvim_win_get_height(0)
--- 	local max_topline = math.max(1, #lines - height + 1)
--- 	saved_view.topline = math.min(saved_view.topline, max_topline)
---
--- 	vim.fn.winrestview(saved_view)
--- end
 
 ---Toggle span in timeline and render its child
 ---@param span_id integer

--- a/lua/observe/ui/view.lua
+++ b/lua/observe/ui/view.lua
@@ -1,5 +1,6 @@
 local constants = require("observe.constants")
 local utils = require("observe.utils.metadata")
+local line_util = require("observe.utils.line")
 
 local M = {}
 
@@ -44,8 +45,11 @@ local function render_top_slow_spans(spans)
 	for i = 1, math.min(10, #spans) do
 		local span = spans[i]
 		local index = #lines + 1
-		lines[index] =
-			{ span_id = span.id, line = utils.format_info(span), source = span.meta and span.meta.full_source }
+		lines[index] = {
+			span_id = span.id,
+			line = " " .. line_util.format_info(span),
+			source = span.meta and span.meta.full_source,
+		}
 	end
 	return lines
 end
@@ -186,6 +190,10 @@ local function render_timeline(spans)
 					end
 				end
 
+				if not has_children then
+					depth = depth + 1
+				end
+
 				---@type TreeInfo
 				local tree_info = {
 					depth = depth,
@@ -194,7 +202,7 @@ local function render_timeline(spans)
 
 				lines[#lines + 1] = {
 					span_id = curr_span.id,
-					line = utils.format_info(curr_span, tree_info),
+					line = line_util.format_info(curr_span, tree_info),
 					source = curr_span.meta and curr_span.meta.full_source,
 				}
 			end
@@ -214,19 +222,20 @@ function M.render(spans)
 	local lines = {}
 	local timeline = {}
 
-	lines[#lines + 1] = constants.PLUGIN_NAME .. " --- Report"
-	lines[#lines + 1] = string.rep("-", #lines[1])
+	lines[#lines + 1] = line_util.render_line(constants.PLUGIN_NAME .. " --- Report")
+	lines[#lines + 1] = line_util.render_line(string.rep("-", #lines[1]))
 
 	local total_ns = 0
 	for _, s in ipairs(spans) do
 		total_ns = total_ns + (s.duration_ns or 0)
 	end
 
-	lines[#lines + 1] = string.format("spans: %d | total: %.2fms", #spans, utils.ns_to_ms(total_ns))
+	lines[#lines + 1] =
+		line_util.render_line(string.format("spans: %d | total: %.2fms", #spans, utils.ns_to_ms(total_ns)))
 
 	if #spans == 0 then
 		lines[#lines + 1] = ""
-		lines[#lines + 1] = "No spans recorded!"
+		lines[#lines + 1] = line_util.render_line("No spans recorded!")
 		return lines, {}
 	end
 
@@ -251,7 +260,7 @@ function M.render(spans)
 
 		for _, v in ipairs(category) do
 			local index = #buf_lines + 1
-			buf_lines[index] = v.line
+			buf_lines[index] = line_util.render_line(v.line)
 			extmarks[index] = { source = v.source, span_id = v.span_id }
 		end
 	end

--- a/lua/observe/ui/view.lua
+++ b/lua/observe/ui/view.lua
@@ -5,7 +5,6 @@ local M = {}
 
 ---@type ReportUIState
 local state = {
-	show_timeline = true,
 	max_timeline_spans = 0,
 	info_extmarks = {},
 	timeline_extmarks = {},
@@ -29,11 +28,6 @@ function M.configure(opts)
 	if opts and opts.max_timeline_spans then
 		state.max_timeline_spans = math.max(constants.MIN_TIMELINE_SPANS, opts.max_timeline_spans)
 	end
-end
-
----Toggle timeline show/hide status
-function M.toggle_timeline_view()
-	state.show_timeline = not state.show_timeline
 end
 
 ---Render top 10 slowest spans
@@ -141,20 +135,9 @@ end
 local function render_timeline(spans)
 	local lines = {}
 
-	local timeline_header = (state.show_timeline and "▼" or "►") .. " Timeline"
-	local header_with_hint = timeline_header
-	-- TODO: idk what to do with this now
-	-- if not state.show_timeline then
-	-- 	header_with_hint = header_with_hint .. " (press t to reveal)"
-	-- end
-
+	local timeline_header = "Timeline"
 	lines[#lines + 1] = { line = "" }
-	lines[#lines + 1] = { line = header_with_hint }
-
-	if not state.show_timeline then
-		return lines
-	end
-
+	lines[#lines + 1] = { line = timeline_header }
 	lines[#lines + 1] = { line = string.rep("-", #timeline_header) }
 
 	if #spans <= 0 then

--- a/lua/observe/ui/view.lua
+++ b/lua/observe/ui/view.lua
@@ -5,15 +5,22 @@ local M = {}
 
 ---@type ReportUIState
 local state = {
-	show_timeline = false,
+	show_timeline = true,
 	max_timeline_spans = 0,
-	extmarks = {},
+	info_extmarks = {},
+	timeline_extmarks = {},
 }
 
----Get current extmarks for rendered lines, used for source preview on line hover
+---Get current extmarks for rendered info
 ---@return table<integer, ExtInfo>
-function M.get_extmarks()
-	return state.extmarks
+function M.get_info_extmarks()
+	return state.info_extmarks
+end
+
+---Get extmarks for rendered timeline
+---@return table<integer, ExtInfo>
+function M.get_timeline_extmarks()
+	return state.timeline_extmarks
 end
 
 ---Configure view state
@@ -40,13 +47,8 @@ local function render_top_slow_spans(spans)
 	lines[#lines + 1] = { line = header }
 	lines[#lines + 1] = { line = string.rep("-", #header) }
 
-	local spans_copy = vim.tbl_extend("force", {}, spans) ---@type ObserveSpan[]
-	table.sort(spans_copy, function(a, b)
-		return (a.duration_ns or 0) > (b.duration_ns or 0)
-	end)
-
-	for i = 1, math.min(10, #spans_copy) do
-		local span = spans_copy[i]
+	for i = 1, math.min(10, #spans) do
+		local span = spans[i]
 		local index = #lines + 1
 		lines[index] =
 			{ span_id = span.id, line = utils.format_info(span), source = span.meta and span.meta.full_source }
@@ -77,10 +79,10 @@ local function render_total_duration_by_key(spans, key)
 				val = tostring(val)
 			end
 		else
-			val = span.meta[key]
+			val = (span.meta or {})[key]
 			if not val then
 				-- No key found inside span and span.meta
-				return {}
+				goto continue
 			end
 
 			if type(val) ~= "string" then
@@ -103,6 +105,7 @@ local function render_total_duration_by_key(spans, key)
 			duration = ((merged_by_filter[data] or {}).duration or 0) + (span.duration_ns or 0),
 			source = span.meta and span.meta.full_source,
 		}
+		::continue::
 	end
 
 	local totals_by_key = {} ---@type TotalByKey[]
@@ -125,7 +128,7 @@ local function render_total_duration_by_key(spans, key)
 		local ms = utils.ns_to_ms(merge_meta.duration)
 		lines[#lines + 1] = {
 			span_id = merge_meta.span_id,
-			line = string.format("%s %s%s", utils.render_timestamp(ms), label, merge_meta.key),
+			line = string.format(" %s %s%s", utils.render_timestamp(ms), label, merge_meta.key),
 			source = merge_meta.source,
 		}
 	end
@@ -140,77 +143,77 @@ local function render_timeline(spans)
 
 	local timeline_header = (state.show_timeline and "▼" or "►") .. " Timeline"
 	local header_with_hint = timeline_header
-	if not state.show_timeline then
-		header_with_hint = header_with_hint .. " (press t to reveal)"
-	end
+	-- TODO: idk what to do with this now
+	-- if not state.show_timeline then
+	-- 	header_with_hint = header_with_hint .. " (press t to reveal)"
+	-- end
 
 	lines[#lines + 1] = { line = "" }
 	lines[#lines + 1] = { line = header_with_hint }
 
-	if state.show_timeline then
-		lines[#lines + 1] = { line = string.rep("-", #timeline_header) }
+	if not state.show_timeline then
+		return lines
+	end
 
-		if #spans <= 0 then
-			lines[#lines + 1] = { line = "No spans recorded!" }
-			return lines
+	lines[#lines + 1] = { line = string.rep("-", #timeline_header) }
+
+	if #spans <= 0 then
+		lines[#lines + 1] = { line = "No spans recorded!" }
+		return lines
+	end
+
+	local spans_copy = vim.tbl_deep_extend("force", {}, spans)
+	table.sort(spans_copy, function(a, b)
+		return (a.start_ns or 0) < (b.start_ns or 0)
+	end)
+
+	-- Build tree by parent_id (REAL nesting)
+	local roots = {} ---@type integer[]
+	local children = {} ---@type table<integer, integer[]>
+
+	for i, s in ipairs(spans_copy) do
+		if s.parent_id then
+			children[s.parent_id] = children[s.parent_id] or {}
+			table.insert(children[s.parent_id], i)
+		else
+			table.insert(roots, i)
 		end
+	end
 
-		table.sort(spans, function(a, b)
-			return a.start_ns < b.start_ns
-		end)
+	local seen_ids = {} ---@type table<integer, boolean>
 
-		local roots = {} ---@type integer[]
-		local children = {} ---@type table<integer, integer[]>
-		for i, v in ipairs(spans) do
-			if v.parent_id then
-				children[v.parent_id] = children[v.parent_id] or {}
-				table.insert(children[v.parent_id], i)
-			else
-				table.insert(roots, i)
-			end
-		end
+	for _, root_i in ipairs(roots) do
+		local stack = { { idx = root_i, depth = 0 } }
 
-		local seen_ids = {}
-		for ri = 1, #roots do
-			local depth = 0
-			local root_si = roots[ri]
-			local stack = { root_si } -- stack of indices
+		while #stack > 0 do
+			local node = table.remove(stack) -- pop
+			local span_index = node.idx
+			local depth = node.depth
 
-			while #stack > 0 do
-				local span_index = table.remove(stack)
-				local curr_span = spans[span_index]
+			local curr_span = spans_copy[span_index]
+			if curr_span and not seen_ids[curr_span.id] then
+				seen_ids[curr_span.id] = true
 
-				if curr_span and not seen_ids[curr_span.id] then
-					seen_ids[curr_span.id] = true
+				local kids = children[curr_span.id]
+				local has_children = kids and #kids > 0
 
-					local kids = children[curr_span.id]
-					local has_children = kids and #kids > 0
-					if has_children and not curr_span.collapsed then
-						for ci = #kids, 1, -1 do
-							local child_i = kids[ci]
-							local child_span = spans[child_i]
-							if not seen_ids[child_span.id] then
-								table.insert(stack, child_i)
-							end
-						end
-					end
-
-					---@type TreeInfo
-					local tree_info = {
-						depth = depth,
-						has_children = has_children,
-					}
-
-					lines[#lines + 1] = {
-						span_id = curr_span.id,
-						line = utils.format_info(curr_span, tree_info),
-						source = curr_span.meta and curr_span.meta.full_source,
-					}
-
-					if has_children and not curr_span.collapsed then
-						depth = depth + 1
+				if has_children and not curr_span.collapsed then
+					for ci = #kids, 1, -1 do
+						table.insert(stack, { idx = kids[ci], depth = depth + 1 })
 					end
 				end
+
+				---@type TreeInfo
+				local tree_info = {
+					depth = depth,
+					has_children = has_children,
+				}
+
+				lines[#lines + 1] = {
+					span_id = curr_span.id,
+					line = utils.format_info(curr_span, tree_info),
+					source = curr_span.meta and curr_span.meta.full_source,
+				}
 			end
 		end
 	end
@@ -219,11 +222,14 @@ local function render_timeline(spans)
 end
 
 ---Generate report based on spans
+---returns top 10s and timeline
 ---@param spans ObserveSpan[]
----@return string[]
+---@return string[], string[]
 function M.render(spans)
-	state.extmarks = {}
+	state.info_extmarks = {}
+	state.timeline_extmarks = {}
 	local lines = {}
+	local timeline = {}
 
 	lines[#lines + 1] = constants.PLUGIN_NAME .. " --- Report"
 	lines[#lines + 1] = string.rep("-", #lines[1])
@@ -238,26 +244,37 @@ function M.render(spans)
 	if #spans == 0 then
 		lines[#lines + 1] = ""
 		lines[#lines + 1] = "No spans recorded!"
-		return lines
+		return lines, {}
 	end
+
+	table.sort(spans, function(a, b)
+		return a.duration_ns > b.duration_ns
+	end)
 
 	local categories = {
 		render_top_slow_spans(spans),
 		render_total_duration_by_key(spans, "source"),
 		render_total_duration_by_key(spans, "name"),
-		render_timeline(spans),
+		render_timeline(spans), -- always keep at bottom
 	}
 
-	for _, category in ipairs(categories) do
+	local buf_lines = lines
+	local extmarks = state.info_extmarks
+	for i, category in ipairs(categories) do
+		if i == #categories then
+			buf_lines = timeline
+			extmarks = state.timeline_extmarks
+		end
+
 		for _, v in ipairs(category) do
-			local index = #lines + 1
-			lines[index] = v.line
-			state.extmarks[index] = { source = v.source, span_id = v.span_id }
+			local index = #buf_lines + 1
+			buf_lines[index] = v.line
+			extmarks[index] = { source = v.source, span_id = v.span_id }
 		end
 	end
 
 	lines[#lines + 1] = ""
-	return lines
+	return lines, timeline
 end
 
 return M

--- a/lua/observe/utils/line.lua
+++ b/lua/observe/utils/line.lua
@@ -1,0 +1,42 @@
+local metadata = require("observe.utils.metadata")
+
+local M = {}
+
+---Render nfo from span
+---@param span ObserveSpan
+---@param tree_info TreeInfo?
+---@return string
+function M.format_info(span, tree_info)
+	local source, data = metadata.parse_info_from_meta(span.meta)
+	if source ~= "" then
+		if span.meta and (span.meta.type == "async_cmd" or span.meta.type == "cmd") then
+			source = ""
+		else
+			source = string.format("(%s) ", source)
+		end
+	end
+
+	local suffix = #data > 0 and ("  [" .. table.concat(data, " | ") .. "]") or ""
+	local timestamp = metadata.ns_to_ms(span.duration_ns or 0)
+	local line = string.format("%s %s%s%s", metadata.render_timestamp(timestamp), span.name, source, suffix)
+
+	if tree_info and tree_info.depth >= 0 then
+		local pad = string.rep("  ", tree_info.depth)
+		if tree_info.has_children then
+			local icon = span.collapsed and "▶" or "▼"
+			line = icon .. "\t" .. line
+		end
+		line = pad .. line
+	end
+
+	return line
+end
+
+---Render line with left padding
+---@param line string
+---@return string
+function M.render_line(line)
+	return "\t" .. line
+end
+
+return M

--- a/lua/observe/utils/metadata.lua
+++ b/lua/observe/utils/metadata.lua
@@ -63,7 +63,11 @@ end
 function M.format_info(span, tree_info)
 	local source, data = M.parse_info_from_meta(span.meta)
 	if source ~= "" then
-		source = string.format(" (%s) ", source)
+		if span.meta and (span.meta.type == "async_cmd" or span.meta.type == "cmd") then
+			source = ""
+		else
+			source = string.format(" (%s) ", source)
+		end
 	end
 
 	local suffix = #data > 0 and ("  [" .. table.concat(data, " | ") .. "]") or ""

--- a/lua/observe/utils/metadata.lua
+++ b/lua/observe/utils/metadata.lua
@@ -56,36 +56,4 @@ function M.parse_info_from_meta(meta)
 	return source, parts
 end
 
----Render info from span
----@param span ObserveSpan
----@param tree_info TreeInfo?
----@return string
-function M.format_info(span, tree_info)
-	local source, data = M.parse_info_from_meta(span.meta)
-	if source ~= "" then
-		if span.meta and (span.meta.type == "async_cmd" or span.meta.type == "cmd") then
-			source = ""
-		else
-			source = string.format(" (%s) ", source)
-		end
-	end
-
-	local suffix = #data > 0 and ("  [" .. table.concat(data, " | ") .. "]") or ""
-	local timestamp = M.ns_to_ms(span.duration_ns or 0)
-	local line = string.format(" %s %s%s%s", M.render_timestamp(timestamp), span.name, source, suffix)
-
-	if tree_info and tree_info.depth >= 0 then
-		local pad = string.rep("  ", tree_info.depth)
-		if tree_info.has_children then
-			local icon = span.collapsed and "▶" or "▼"
-			line = icon .. line
-		else
-			line = " " .. line
-		end
-		line = pad .. line
-	end
-
-	return line
-end
-
 return M

--- a/lua/observe/utils/win.lua
+++ b/lua/observe/utils/win.lua
@@ -1,0 +1,41 @@
+local path_utils = require("observe.utils.path")
+local extmarks = require("observe.utils.extmarks")
+
+local M = {}
+
+---Close current window
+function M.close_window()
+	local wins = vim.api.nvim_list_wins()
+	if #wins > 1 then
+		-- if there are more than 1 window, close the current window
+		pcall(vim.api.nvim_win_close, 0, false)
+		return
+	end
+
+	-- if there is only 1 window,
+	-- create a new buffer inside the window and close the current report buffer
+	local cur_buf = vim.api.nvim_get_current_buf()
+	vim.cmd("enew")
+	pcall(vim.api.nvim_buf_delete, cur_buf, { force = true })
+end
+
+---Open file using source from current line's extmark if there is any
+---@param buf integer
+---@param ns integer
+function M.open_file(buf, ns)
+	local row = vim.api.nvim_win_get_cursor(0)[1] - 1
+
+	local marks = vim.api.nvim_buf_get_extmarks(buf, ns, { row, 0 }, { row, -1 }, {})
+	if #marks == 0 then
+		return
+	end
+
+	local info = extmarks.get_extmark_data(marks)
+	if not info or not info.source then
+		return
+	end
+
+	path_utils.open_location_enter(buf, info.source)
+end
+
+return M

--- a/lua/observe/utils/win.lua
+++ b/lua/observe/utils/win.lua
@@ -38,4 +38,15 @@ function M.open_file(buf, ns)
 	path_utils.open_location_enter(buf, info.source)
 end
 
+function M.clean_window()
+	vim.wo.number = false
+	vim.wo.relativenumber = false
+	vim.wo.signcolumn = "no"
+	vim.wo.foldcolumn = "0"
+	vim.wo.cursorline = true
+	vim.wo.wrap = false
+	vim.wo.list = false
+	vim.wo.statusline = " "
+end
+
 return M

--- a/plugin/observe.lua
+++ b/plugin/observe.lua
@@ -10,7 +10,6 @@ end, {})
 
 create_command("ObserveStop", function()
 	observe().stop()
-	observe().report()
 end, {})
 
 create_command("ObserveReport", function()

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,1 @@
+syntax = "Lua52"


### PR DESCRIPTION
## Summary

- Implemented dual-buffer report system with separate info and timeline views for better organization and performance
- Added automatic span filtering to exclude noise from very short-lived spans (< 1ms)
- Enhanced source data handling in command adapters with better formatting and fallback labels
- Improved view rendering logic to cleanly separate info display from timeline visualization

## Test Plan

- [ ] Start tracing with `:ObserveStart`
- [ ] Execute some commands and operations
- [ ] Run `:ObserveReport` to view the dual-buffer report
- [ ] Verify spans are properly separated into info and timeline views
- [ ] Test navigation with Enter key to jump to source files
- [ ] Verify timeline expand/collapse with 'e' key works correctly
- [ ] Check that spans less than 1ms are properly filtered out